### PR TITLE
Better auth

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,10 +1,14 @@
 # Evolve SDK connection library
 ## [0.10.0] - UNRELEASED
 ### Breaking Changes
-* None.
+* This is a breaking change as it changes the way the token fetcher works and has to be initialised. It means the clients using the `createTokenFetcher` helper functions or `ZepbenTokenFetcher`
+  class directly would need to be updated to use the new interface.
 
 ### New Features
-* None.
+* A new `AuthProviderConfig` object can now hold the auth config exposed by EWB
+* Simplified set of values exposed by EWB via `AuthConfigRoute`: issuer, audience, authMethod.
+* A new helper functions to create AuthProviderConfig by fetching the data from EWB, and to fetch provider-related configuration (jwkUri, tokenEndpoint)
+* `ZepbenTokenFetcher` is now using the new `AuthProviderConfig` object to fetch the auth config and the token.
 
 ### Enhancements
 * None.
@@ -19,9 +23,7 @@
 * None.
 
 ### New Features
-* A new `AuthProviderConfig` object can now hold the auth config exposed by EWB
-* A new helper functions to create AuthProviderConfig by fetching the data from EWB, and to fetch provider-related configuration (jwkUri, tokenEndpoint)
-* `ZepbenTokenFetcher` is now using the new `AuthProviderConfig` object to fetch the auth config and the token.
+* None.
 
 ### Enhancements
 * None.

--- a/changelog.md
+++ b/changelog.md
@@ -19,7 +19,9 @@
 * None.
 
 ### New Features
-* None.
+* A new `AuthProviderConfig` object can now hold the auth config exposed by EWB
+* `ZepbenTokenFetcher` is now using the new `AuthProviderConfig` object to fetch the auth config and the token.
+* `AuthConfigRoute` now exposes protocol for connecting to EWB and jwkUrl if defined.
 
 ### Enhancements
 * None.

--- a/changelog.md
+++ b/changelog.md
@@ -20,8 +20,8 @@
 
 ### New Features
 * A new `AuthProviderConfig` object can now hold the auth config exposed by EWB
+* A new helper functions to create AuthProviderConfig by fetching the data from EWB, and to fetch provider-related configuration (jwkUri, tokenEndpoint)
 * `ZepbenTokenFetcher` is now using the new `AuthProviderConfig` object to fetch the auth config and the token.
-* `AuthConfigRoute` now exposes protocol for connecting to EWB and jwkUrl if defined.
 
 ### Enhancements
 * None.

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.zepben.evolve</groupId>
     <artifactId>evolve-conn</artifactId>
-    <version>0.10.0-SNAPSHOT2</version>
+    <version>0.10.0-SNAPSHOT666</version>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A collection of utilities to create and manage connections between Zepben services and clients.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.zepben.evolve</groupId>
     <artifactId>evolve-conn</artifactId>
-    <version>0.10.0-SNAPSHOT666</version>
+    <version>0.10.0-SNAPSHOT2</version>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A collection of utilities to create and manage connections between Zepben services and clients.</description>

--- a/src/main/kotlin/com/zepben/auth/client/AuthProviderConfig.kt
+++ b/src/main/kotlin/com/zepben/auth/client/AuthProviderConfig.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.auth.client
+
+import com.zepben.auth.common.AuthException
+import com.zepben.auth.common.AuthMethod
+import com.zepben.auth.common.StatusCode
+import io.vertx.core.json.DecodeException
+import io.vertx.core.json.Json
+import io.vertx.core.json.JsonObject
+import java.io.IOException
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+data class ProviderDetails(
+    val tokenEndpoint: String,
+    val jwkUrl: String
+)
+
+data class AuthProviderConfig(
+    val issuer: String,
+    val audience: String,
+    val authType: AuthMethod = AuthMethod.OAUTH,
+    val providerDetails: ProviderDetails = ProviderDetails("", "")
+)
+
+/**
+ * Helper method to fetch the provider-related auth configuration
+ *
+ * @param issuer Location to retrieve the configuration from. Must be a HTTP address that returns a JSON response.
+ * @param client HTTP client used to retrieve the provider configuration.
+ * @param handler an HTTP handler used to handle the HTTP response.
+ *
+ * @returns: A `ProviderDetails` if successfully contacted the issuer, error otherwise
+ */
+fun fetchProviderDetails(
+    issuer: String,
+    client: HttpClient = HttpClient.newBuilder().sslContext(SSLContextUtils.allTrustingSSLContext()).build(),
+    handler: HttpResponse.BodyHandler<String> = HttpResponse.BodyHandlers.ofString()
+): ProviderDetails {
+    val issuerURL = "$issuer/.well-known/openid-configuration"
+    val response = client.send(HttpRequest.newBuilder().uri(URI(issuerURL)).GET().build(), handler)
+    if (response.statusCode() == StatusCode.OK.code) {
+        try {
+            val authConfigJson = Json.decodeValue(response.body()) as JsonObject
+            return ProviderDetails(
+                tokenEndpoint = authConfigJson.getString("token_endpoint", ""),
+                jwkUrl = authConfigJson.getString("jwks_uri", ""),
+            )
+
+        } catch (e: DecodeException) {
+            throw AuthException(
+                response.statusCode(),
+                "Expected JSON response from $issuerURL, but got: ${response.body()}."
+            )
+        } catch (e: ClassCastException) {
+            throw AuthException(
+                response.statusCode(),
+                "Expected JSON object from $issuerURL, but got: ${response.body()}."
+            )
+        }
+    } else {
+        throw AuthException(
+            response.statusCode(),
+            "$issuerURL responded with error: ${response.statusCode()} - ${response.body()}"
+        )
+    }
+}
+
+/**
+ * Helper method to fetch auth related configuration from `confAddress` and create a `ZepbenTokenFetcher`.
+ *
+ * @param confAddress Location to retrieve authentication configuration from. Must be a HTTP address that returns a JSON response.
+ * @param client HTTP client used to retrieve the authentication configuration.
+ * @param handler an HTTP handler used to handle the HTTP response.
+ * @param audienceField The field name to look up in the JSON response from the confAddress for `audience`.
+ * @param issuerField The field name to look up in the JSON response from the confAddress for `issuer`.
+ *
+ * @returns: A `AuthProviderConfig` with `ProviderDetails` automatically populated if no errors, an error otherwise.
+ */
+fun createProviderConfig(
+    confAddress: String,
+    client: HttpClient = HttpClient.newBuilder().sslContext(SSLContextUtils.allTrustingSSLContext()).build(),
+    handler: HttpResponse.BodyHandler<String> = HttpResponse.BodyHandlers.ofString(),
+    authTypeField: String = "authType",
+    audienceField: String = "audience",
+    issuerField: String = "issuer"
+): AuthProviderConfig {
+
+    // Fetch the auth data from EWB
+    val response = try {
+        // Try with https first
+        client.send(HttpRequest.newBuilder().uri(URI(confAddress)).GET().build(), handler)
+    } catch (e: IOException) {
+        throw AuthException(1, "Fetching auth configuration from $confAddress failed, check you've provided the full URL with correct protocol")
+    }
+
+    return response?.let {
+        if (response.statusCode() == StatusCode.OK.code) {
+            try {
+                val authConfigJson = Json.decodeValue(response.body()) as JsonObject
+                val issuer = authConfigJson.getString(issuerField, "")
+                val authMethod = AuthMethod.valueOf(authConfigJson.getString(authTypeField, "none").uppercase())
+
+                if (authMethod == AuthMethod.NONE) {
+                    throw AuthException(
+                        1,
+                        "Detected Auth set to NONE, this is not supported for fetching tokens! Check your configuration matches $confAddress"
+                    )
+                }
+
+                AuthProviderConfig(
+                    authType = authMethod,
+                    issuer = issuer,
+                    audience = authConfigJson.getString(audienceField, ""),
+                    providerDetails = fetchProviderDetails(issuer, client, handler)
+                )
+            } catch (e: DecodeException) {
+                throw AuthException(
+                    response.statusCode(),
+                    "Expected JSON response from $confAddress, but got: ${response.body()}."
+                )
+            } catch (e: ClassCastException) {
+                throw AuthException(
+                    response.statusCode(),
+                    "Expected JSON object from $confAddress, but got: ${response.body()}."
+                )
+            }
+        } else {
+            throw AuthException(
+                response.statusCode(),
+                "$confAddress responded with error: ${response.statusCode()} - ${response.body()}"
+            )
+        }
+    } ?: throw AuthException(1, "Unexpected error while attempting to fetch auth details from $confAddress")
+}

--- a/src/main/kotlin/com/zepben/auth/server/AuthConfigRoute.kt
+++ b/src/main/kotlin/com/zepben/auth/server/AuthConfigRoute.kt
@@ -21,29 +21,24 @@ import io.vertx.ext.web.RoutingContext
 
 private data class AuthConfigResponse(
     val authType: AuthMethod,
-    val issuerDomain: String,
-    val audience: String,
-    val tokenPath: String,
-    val algorithm: String = "RS256"
+    val issuer: String,
+    val audience: String
 )
 
 fun routeFactory(
     availableRoute: AvailableRoute,
     audience: String,
-    domain: String,
-    tokenPath: String,
-    authType: AuthMethod = AuthMethod.AUTH0,
-    algorithm: String = "RS256"
+    issuer: String,
+    authType: AuthMethod = AuthMethod.OAUTH
 ): Route =
     when (availableRoute) {
         AvailableRoute.AUTH_CONFIG ->
             Route.builder()
                 .method(HttpMethod.GET)
                 .path("/auth")
-                .addHandler(AuthConfigRoute(audience, domain, tokenPath, authType))
+                .addHandler(AuthConfigRoute(audience, issuer, authType))
                 .build()
 
-        else -> throw IllegalArgumentException("Invalid Route")
     }
 
 enum class AvailableRoute(private val rv: RouteVersion) : VersionableRoute {
@@ -54,9 +49,10 @@ enum class AvailableRoute(private val rv: RouteVersion) : VersionableRoute {
     }
 }
 
-class AuthConfigRoute(audience: String, domain: String, tokenPath: String, authType: AuthMethod, algorithm: String = "RS256") : Handler<RoutingContext> {
+class AuthConfigRoute(audience: String, issuer: String, authType: AuthMethod) : Handler<RoutingContext> {
 
-    private val json: JsonObject = JsonObject.mapFrom(AuthConfigResponse(authType, domain, audience, tokenPath, algorithm))
+    private val json: JsonObject =
+        JsonObject.mapFrom(AuthConfigResponse(authType = authType, audience = audience, issuer = issuer))
 
     override fun handle(event: RoutingContext) {
         Respond.withJson(event, HttpResponseStatus.OK, json.encode())

--- a/src/test/kotlin/com/zepben/auth/server/AuthProviderConfigRouteTest.kt
+++ b/src/test/kotlin/com/zepben/auth/server/AuthProviderConfigRouteTest.kt
@@ -9,7 +9,6 @@
 
 package com.zepben.auth.server
 
-
 import com.zepben.auth.common.AuthMethod
 import com.zepben.vertxutils.routing.RouteVersionUtils
 import com.zepben.vertxutils.testing.TestHttpServer
@@ -21,7 +20,8 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
-class AuthConfigRouteTest {
+class AuthProviderConfigRouteTest {
+
     private var server: TestHttpServer? = null
     private var port = 8080
 
@@ -29,9 +29,16 @@ class AuthConfigRouteTest {
     fun before() {
         server = TestHttpServer().addRoutes(
             RouteVersionUtils.forVersion(
-                AvailableRoute.values(),
+                AvailableRoute.entries.toTypedArray(),
                 2
-            ) { routeFactory(it, "test-audience", "test-issuer", "test-token-path", AuthMethod.AUTH0) }
+            ) {
+                routeFactory(
+                    it,
+                    audience = "test-audience",
+                    issuer = "test-issuer",
+                    authType = AuthMethod.AUTH0,
+                )
+            }
         )
         port = server!!.listen()
     }
@@ -40,10 +47,8 @@ class AuthConfigRouteTest {
     fun testHandle() {
         val expectedResponse: String = JsonObject().apply {
             put("authType", AuthMethod.AUTH0)
-            put("issuerDomain", "test-issuer")
+            put("issuer", "test-issuer")
             put("audience", "test-audience")
-            put("tokenPath", "test-token-path")
-            put("algorithm", "RS256")
         }.encode()
 
         val response = RestAssured.given()

--- a/src/test/kotlin/com/zepben/evolve/conn/grpc/ExceptionInterceptorTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/conn/grpc/ExceptionInterceptorTest.kt
@@ -8,11 +8,6 @@
 
 package com.zepben.evolve.conn.grpc
 
-import com.zepben.testutils.auth.MockServerCall
-import com.zepben.testutils.auth.MockServerCallHandler
-import io.grpc.Metadata
-import io.grpc.ServerCall
-import io.grpc.ServerInterceptor
 import io.grpc.Status
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers


### PR DESCRIPTION
This is a rewrite to Auth functionality to unify EntraID and Auth0 to the same flow. It also implements fetching information from EWB in the centralised fashion, allowing clients to do this independently.


* Provide a new AuthProviderConfig object to hold auth config exposed by EWB and/or auth provider
* Provide a function call to fetch the auth config from EWB
* Provide a function call to fetch the provider-related info (jwkUri, iss, tokenEndpoint)
* Replace fetching the auth config in ZepbenTokenFetcher to using the new `AuthProviderConfig`
* Unify EntraID and Auth0 calls into OAUTH method
* Remove all tokenPath params

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

This is a breaking change as it changes the way the token fetcher works and has to be initialised. It means the clients using the `createTokenFetcher` helper functions or `ZepbenTokenFetcher` class directly would need to be updated to use the new interfaces.