### PR TITLE
DEV-1135 Support lazy fetching of provider details for TrustedIssuers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@
 * `JWTAuthenticator` now supports authenticating tokens from multiple different issues via the use of `JWTMultiIssuerVerifierBuilder`.
 * `JWTMultiIssuerVerifierBuilder` will create a JWTVerifier based on the `iss` (issuer) of the token provided to `getVerifier()`. The returned JWTVerifier will
   also validate that the audience claim matches the `requiredAudience` supplied to the `JWTMultiIssuerVerifierBuilder`.
+* `TrustedIssuer` now supports lazy fetching of `TrustedIssuer.providerDetails` by accepting a lambda that takes an issuer domain and returns a `ProviderDetails`. 
 
 ### Enhancements
 * None.

--- a/src/main/kotlin/com/zepben/auth/server/TrustedIssuer.kt
+++ b/src/main/kotlin/com/zepben/auth/server/TrustedIssuer.kt
@@ -9,8 +9,16 @@
 package com.zepben.auth.server
 
 import com.zepben.auth.client.ProviderDetails
+import com.zepben.auth.client.fetchProviderDetails
 
 data class TrustedIssuer(
     val issuerDomain: String,
-    val providerDetails: ProviderDetails
-)
+    private val providerDetailsProvider: (String) -> ProviderDetails = { fetchProviderDetails(issuerDomain) }
+) {
+
+    constructor(issuerDomain: String, providerDetails: ProviderDetails) : this(issuerDomain, { _ -> providerDetails } )
+
+    val providerDetails: ProviderDetails by lazy {
+        providerDetailsProvider(issuerDomain)
+    }
+}

--- a/src/test/kotlin/com/zepben/auth/server/TrustedIssuerTest.kt
+++ b/src/test/kotlin/com/zepben/auth/server/TrustedIssuerTest.kt
@@ -1,0 +1,37 @@
+package com.zepben.auth.server
+
+import com.zepben.auth.client.ProviderDetails
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+
+class TrustedIssuerTest {
+
+    @Test
+    fun lazyFetchWorksAsExpected() {
+        var runCount = 0
+        val underTest = TrustedIssuer(issuerDomain = "real.cool.au") { input -> runCount++; ProviderDetails("$input plus token path", "$input/jwks.json") }
+
+        assertThat(runCount, equalTo(0))
+        val providerDetails = underTest.providerDetails
+        assertThat(runCount, equalTo(1))
+        assertThat(providerDetails.tokenEndpoint, equalTo("real.cool.au plus token path"))
+        assertThat(providerDetails.jwkUrl, equalTo("real.cool.au/jwks.json"))
+        assertThat(underTest.issuerDomain, equalTo("real.cool.au"))
+
+        //confirm that the details are only fetched once
+        assertThat(underTest.providerDetails.tokenEndpoint, equalTo("real.cool.au plus token path"))
+        assertThat(underTest.providerDetails.jwkUrl, equalTo("real.cool.au/jwks.json"))
+        assertThat(underTest.issuerDomain, equalTo("real.cool.au"))
+        assertThat(runCount, equalTo(1))
+    }
+
+    @Test
+    fun secondaryConstructorWorksAsExpected() {
+        val underTest = TrustedIssuer(issuerDomain = "real.cool.au", ProviderDetails("caller.provided/token", "caller.aye/other/jwks.json"))
+
+        assertThat(underTest.providerDetails.tokenEndpoint, equalTo("caller.provided/token"))
+        assertThat(underTest.providerDetails.jwkUrl, equalTo("caller.aye/other/jwks.json"))
+        assertThat(underTest.issuerDomain, equalTo("real.cool.au"))
+    }
+}


### PR DESCRIPTION
# Description

`TrustedIssuer` now supports lazy fetching of `TrustedIssuer.providerDetails` by accepting a lambda that takes an issuer domain and returns a `ProviderDetails`.

The reason for this implementation change is so EAS can lazily fetch provider details from itself (so it can trust its tokens it itself has created/signed) instead of trying to populate these details during start up before the EAS webserver has actually started serving its OpenID configuration endpoint as added by 
- https://github.com/zepben/evolve-app-server/pull/126

# Associated tasks

Required to be merged before:
- https://github.com/zepben/evolve-app-server/pull/130


# Test Steps

* Build EAS from https://github.com/zepben/evolve-app-server/pull/130
* Enable entraId auth with local dev details 
* Add the host name of EAS (probably http://localhost:6543) to the list of `auth.trustedIssues` in the config
* Confirm that EAS starts. 
* Extra credit: Create yourself a personal access token as described in the above PR and check that it is actually trusted by EAS by making some graphQL requests to it.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

:woman_shrugging: This seems like it should be a breaking change in a core auth library but I believe that with the new secondary constructor it's backwards compatible and would continue to work without any code change in existing code. 
