### PR TITLE
[DEV-1778] Allow disabling cert verification when fetching JWKS keys

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Evolve SDK connection library
 ## [0.12.0] - UNRELEASED
 ### Breaking Changes
-* None.
+* Update `fetchProviderDetails` to allow downstream users to set certificate verification. In addition, the default is changed for trust all certificates to using the default system store
 
 ### New Features
 * None.
@@ -10,7 +10,7 @@
 * Replace use of the Auth0 `UrlJwkProvider` with our own `ConfigurableJwkProvider` so that we can customize the certificate verification behavior
 
 ### Fixes
-* None.
+* None
 
 ### Notes
 * None.

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@
 * None.
 
 ### Enhancements
-* None.
+* Replace use of the Auth0 `UrlJwkProvider` with our own `ConfigurableJwkProvider` so that we can customize the certificate verification behavior
 
 ### Fixes
 * None.

--- a/src/main/kotlin/com/zepben/auth/client/ZepbenTokenFetcher.kt
+++ b/src/main/kotlin/com/zepben/auth/client/ZepbenTokenFetcher.kt
@@ -232,7 +232,7 @@ fun createTokenFetcher(
         authMethod = authMethod,
         issuer = issuer,
         audience = audience,
-        providerDetails = fetchProviderDetails(issuer = issuer, client = client)
+        providerDetails = fetchProviderDetails(issuer = issuer, httpClientCreator = { client })
     )
 
     return ZepbenTokenFetcher(
@@ -262,7 +262,7 @@ fun createTokenFetcher(
     issuerField: String = "issuer",
 ): ZepbenTokenFetcher {
     val config = createProviderConfig(
-        client = confClient,
+        httpClientCreator = { confClient },
         confAddress = confAddress,
         audienceField = audienceField,
         issuerField = issuerField,

--- a/src/main/kotlin/com/zepben/auth/server/ConfigurableJwkProvider.kt
+++ b/src/main/kotlin/com/zepben/auth/server/ConfigurableJwkProvider.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.auth.server
+
+import com.auth0.jwk.Jwk
+import com.auth0.jwk.JwkProvider
+import com.auth0.jwk.SigningKeyNotFoundException
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.zepben.auth.client.SSLContextUtils
+import com.zepben.auth.common.StatusCode
+import java.net.URL
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+
+class ConfigurableJwkProvider(
+    private val url: URL,
+    verifyCertificates: Boolean,
+    val httpClientCreator: () -> HttpClient = {
+        if (!verifyCertificates) {
+            HttpClient.newBuilder().sslContext(SSLContextUtils.allTrustingSSLContext()).build()
+        } else {
+            HttpClient.newBuilder().build()
+        }
+    }
+) : JwkProvider {
+    val allKeys by lazy { getAll() }
+
+    private fun getAll(): List<Jwk> {
+        val client = httpClientCreator()
+        val request = HttpRequest.newBuilder()
+            .uri(url.toURI())
+            .header(CONTENT_TYPE, "application/json")
+            .GET()
+            .build()
+
+        val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+
+        if (response.statusCode() != StatusCode.OK.code) {
+            throw SigningKeyNotFoundException("Cannot obtain jwks from url $url", null)
+        }
+
+        val reader = ObjectMapper().readerFor(MutableMap::class.java)
+        val thing = reader.readValue<Map<String, Any>>(response.body())
+
+        val keys = thing["keys"] as List<Map<String, Any>>
+
+        return keys.map { Jwk.fromValues(it) }
+    }
+
+    override fun get(keyId: String?): Jwk {
+        return allKeys.firstOrNull { it.id == keyId } ?: throw SigningKeyNotFoundException("No key found in $url with kid $keyId", null)
+    }
+}

--- a/src/main/kotlin/com/zepben/auth/server/JWKHolder.kt
+++ b/src/main/kotlin/com/zepben/auth/server/JWKHolder.kt
@@ -8,16 +8,15 @@
 
 package com.zepben.auth.server
 
-import com.auth0.jwk.Jwk
-import com.auth0.jwk.JwkException
-import com.auth0.jwk.UrlJwkProvider
+import com.auth0.jwk.*
 import java.net.URI
 import java.net.URL
 
 fun trustedIssuerUrlJwkProvider(
     issuer: TrustedIssuer,
-    urlJwkProviderProvider: (URL) -> UrlJwkProvider = { url -> UrlJwkProvider(url) }
-) = urlJwkProviderProvider(URI(issuer.providerDetails.jwkUrl).toURL()).all.associateBy { it.id }
+    verifyCertificates: Boolean = true,
+    urlJwkProviderProvider: (URL) -> ConfigurableJwkProvider = { url -> ConfigurableJwkProvider(url, verifyCertificates) }
+) = urlJwkProviderProvider(URI(issuer.providerDetails.jwkUrl).toURL()).allKeys.associateBy { it.id }
 
 class JWKHolder(
     private val jwkProvider: (TrustedIssuer) -> Map<String, Jwk> = { issuer -> trustedIssuerUrlJwkProvider(issuer) }
@@ -30,3 +29,4 @@ class JWKHolder(
             keys[issuer.issuerDomain]?.get(kid) ?: throw JwkException("Unable to find key $kid in jwk endpoint. Check your JWK URL.")
         }
 }
+

--- a/src/main/kotlin/com/zepben/auth/server/JWKHolder.kt
+++ b/src/main/kotlin/com/zepben/auth/server/JWKHolder.kt
@@ -19,7 +19,8 @@ fun trustedIssuerUrlJwkProvider(
 ) = urlJwkProviderProvider(URI(issuer.providerDetails.jwkUrl).toURL()).allKeys.associateBy { it.id }
 
 class JWKHolder(
-    private val jwkProvider: (TrustedIssuer) -> Map<String, Jwk> = { issuer -> trustedIssuerUrlJwkProvider(issuer) }
+    private val verifyCertificates: Boolean,
+    private val jwkProvider: (TrustedIssuer) -> Map<String, Jwk> = { issuer -> trustedIssuerUrlJwkProvider(issuer, verifyCertificates) }
 ) {
     private var keys: MutableMap<String, Map<String, Jwk>> = mutableMapOf()
 

--- a/src/main/kotlin/com/zepben/auth/server/JWTAuthenticator.kt
+++ b/src/main/kotlin/com/zepben/auth/server/JWTAuthenticator.kt
@@ -41,7 +41,12 @@ interface TokenAuthenticator {
 open class JWTAuthenticator(
     audience: String,
     trustedIssuers: List<TrustedIssuer>,
-    private val verifierBuilder: JWTMultiIssuerVerifierBuilder = JWTMultiIssuerVerifierBuilder(requiredAudience = audience, trustedIssuers = trustedIssuers)
+    verifyCertificates: Boolean = true,
+    private val verifierBuilder: JWTMultiIssuerVerifierBuilder = JWTMultiIssuerVerifierBuilder(
+        requiredAudience = audience,
+        trustedIssuers = trustedIssuers,
+        verifyCertificates = verifyCertificates
+    )
 ) : TokenAuthenticator {
 
     override fun authenticate(token: String?): AuthResponse =

--- a/src/main/kotlin/com/zepben/auth/server/JWTMultiIssuerVerifier.kt
+++ b/src/main/kotlin/com/zepben/auth/server/JWTMultiIssuerVerifier.kt
@@ -19,7 +19,8 @@ import java.security.interfaces.RSAPublicKey
 class JWTMultiIssuerVerifierBuilder(
     private val requiredAudience: String,
     private val trustedIssuers: List<TrustedIssuer>,
-    internal val jwkHolder: JWKHolder = JWKHolder()
+    private val verifyCertificates: Boolean,
+    internal val jwkHolder: JWKHolder = JWKHolder(verifyCertificates)
 ) {
     fun getVerifier(token: DecodedJWT): JWTVerifier {
         val issuer = trustedIssuers.firstOrNull { it.issuerDomain == token.issuer }

--- a/src/test/kotlin/com/zepben/auth/client/AuthProviderConfigTest.kt
+++ b/src/test/kotlin/com/zepben/auth/client/AuthProviderConfigTest.kt
@@ -30,18 +30,21 @@ class AuthProviderConfigTest {
         every { send(any(), handler) } returns response
     }
 
+    val clientCreator = { client}
+    val verifyCertificates = true
+
     @Test
     fun `handles handles issuers with and without slashes`(){
         var issuer = "https://some-issuer/"
 
-        fetchProviderDetails(issuer, client, handler)
+        fetchProviderDetails(issuer, verifyCertificates, clientCreator, handler)
         verify {
             client.send(HttpRequest.newBuilder().uri(URI("https://some-issuer/.well-known/openid-configuration")).GET().build(), handler)
         }
 
         issuer = "https://some-issuer"
 
-        fetchProviderDetails(issuer, client, handler)
+        fetchProviderDetails(issuer, verifyCertificates, clientCreator, handler)
         verify {
             client.send(HttpRequest.newBuilder().uri(URI("https://some-issuer/.well-known/openid-configuration")).GET().build(), handler)
         }

--- a/src/test/kotlin/com/zepben/auth/server/ConfigurableJwkProviderTest.kt
+++ b/src/test/kotlin/com/zepben/auth/server/ConfigurableJwkProviderTest.kt
@@ -1,0 +1,69 @@
+package com.zepben.auth.server
+
+import com.zepben.auth.common.StatusCode
+import io.mockk.every
+import org.hamcrest.MatcherAssert.assertThat
+import io.mockk.mockk
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+import java.net.URL
+import java.net.http.HttpClient
+import java.net.http.HttpResponse
+
+class ConfigurableJwkProviderTest {
+    val clientCreator = { client }
+    val url = URL("http://fake-url.com")
+
+    // Sampled from Microsoft keys
+    val reponseBody = """
+        {
+          "keys": [
+            {
+              "kty": "RSA",
+              "use": "sig",
+              "kid": "iw1BXXcybk07kmtIeeJeIYqas18",
+              "x5t": "iw1BXXcybk07kmtIeeJeIYqas18",
+              "n": "jXmkS1a_ga_ba3tjnIVD-75VhkszCY0LphvRlKI77H5vDL7mwOT5RvW4cTSO9Vd-NgtUqjlUcf1rwBj9hbrtQwOH1YjUAXSqbmIDwtY_GY6Novs2oIDAH-MZaV2FAQEGk_AGDoyS-YWKZkAbVuvZwuNz6n43MV9bx5ECMMGMJBzDkff0Axbt7ePFSBFp4rQPi61MEOseErRirA2ieMKTCWIRr5i_YBceSR8ZSELx0SVaKnNpSBBz0fXxKrcxm12Y35aa7bziZTPWoZS7gKZMRN7fx1RIYXdnrRTanZ1uXqpHi0c10XbNd26yvbbg8Bvmqo1gXSW6XRwDZMVRMit9Zw",
+              "e": "AQAB",
+              "x5c": [
+                "MIIC/TCCAeWgAwIBAgIIReLBDIrfwFowDQYJKoZIhvcNAQELBQAwLTErMCkGA1UEAxMiYWNjb3VudHMuYWNjZXNzY29udHJvbC53aW5kb3dzLm5ldDAeFw0yNDA5MTkwMTMzMjNaFw0yOTA5MTkwMTMzMjNaMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCNeaRLVr+Br9tre2OchUP7vlWGSzMJjQumG9GUojvsfm8MvubA5PlG9bhxNI71V342C1SqOVRx/WvAGP2Fuu1DA4fViNQBdKpuYgPC1j8Zjo2i+zaggMAf4xlpXYUBAQaT8AYOjJL5hYpmQBtW69nC43PqfjcxX1vHkQIwwYwkHMOR9/QDFu3t48VIEWnitA+LrUwQ6x4StGKsDaJ4wpMJYhGvmL9gFx5JHxlIQvHRJVoqc2lIEHPR9fEqtzGbXZjflprtvOJlM9ahlLuApkxE3t/HVEhhd2etFNqdnW5eqkeLRzXRds13brK9tuDwG+aqjWBdJbpdHANkxVEyK31nAgMBAAGjITAfMB0GA1UdDgQWBBTGfJHI1dcHxyfHQq+NppsvRQeVRjANBgkqhkiG9w0BAQsFAAOCAQEAa3Fsadx1Od7qnlXAW3V66iESJTNrzIgMXYfqCJjCy4Ty3TSWCC4DWC7EppvDPRzGjELC4kH+zhnk80U8Zj549URuZz3ut+6CdcnGJGwZEut6NKMi565h5Sm7r6BNMI9Rlz/7HYYdeP7PS2+okJf64J9CCpCjD1zGpg04QMelhHVUilkPok2B8LbxoFqkaJV6OWafLoZxPtTqKPFAxIq4HfP1+1VeED7VFkNbNmFo4Eq0jcRIHGWrX9msPL3fQXwNg8OVm2jPxWRVhpZ7zKqCKaoSbN9YbAgYsXwRSoycjCwxp7ZXUiTUOYKQNIN0KCPdKjGOAFGy0VOpxmu+NfYZaw=="
+              ],
+              "cloud_instance_name": "microsoftonline.com",
+              "issuer": "https://login.microsoftonline.com/d884eee1-c96f-4701-8103-2ba4346db120/v2.0"
+            },
+            {
+              "kty": "RSA",
+              "use": "sig",
+              "kid": "3PaK4EfyBNQu3CtjYsa3YmhQ5E0",
+              "x5t": "3PaK4EfyBNQu3CtjYsa3YmhQ5E0",
+              "n": "iK9_aSUvnRV4zRKEpHK70hPNb04RBDGI5Cni7I1BGWobwH5jsek1xQ8k-7w6_qtxvBpiOi_oPLG11etjhLRTS2HFkKSLxqPIt-86sEIKbfVG1TxeLrwg5fVTiReyPKIDd0tvFFEvHc6bjGZFHZ_EvDfxPExepjaDopCYLJw6S8xFSCp9QlbKnjLLUoyIBapWeQ-tFK4MilQe7aZnssQR1vTuO-R1-zx5KQaaDzs_XbZUp7qpCsCuXoq3boZJEM3E5eZDYgVYBniDCQb1wp5JluYx78fweMYxSVRVB253PCu77ex0diPltJFte_B0FnvwARPMPzO6LGC2Jc71XTUQ0Q",
+              "e": "AQAB",
+              "x5c": [
+                "MIIC/jCCAeagAwIBAgIJAILi1z2L/f5YMA0GCSqGSIb3DQEBCwUAMC0xKzApBgNVBAMTImFjY291bnRzLmFjY2Vzc2NvbnRyb2wud2luZG93cy5uZXQwHhcNMjQwOTI2MTkyNzI3WhcNMjkwOTI2MTkyNzI3WjAtMSswKQYDVQQDEyJhY2NvdW50cy5hY2Nlc3Njb250cm9sLndpbmRvd3MubmV0MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAiK9/aSUvnRV4zRKEpHK70hPNb04RBDGI5Cni7I1BGWobwH5jsek1xQ8k+7w6/qtxvBpiOi/oPLG11etjhLRTS2HFkKSLxqPIt+86sEIKbfVG1TxeLrwg5fVTiReyPKIDd0tvFFEvHc6bjGZFHZ/EvDfxPExepjaDopCYLJw6S8xFSCp9QlbKnjLLUoyIBapWeQ+tFK4MilQe7aZnssQR1vTuO+R1+zx5KQaaDzs/XbZUp7qpCsCuXoq3boZJEM3E5eZDYgVYBniDCQb1wp5JluYx78fweMYxSVRVB253PCu77ex0diPltJFte/B0FnvwARPMPzO6LGC2Jc71XTUQ0QIDAQABoyEwHzAdBgNVHQ4EFgQUYhedQ9z69v89gqGLjg3axhZbdXQwDQYJKoZIhvcNAQELBQADggEBAEvVdYEokUB9BA7Z1RRU2XpiF/aNbUdXwCCYIQvHqW3++tLI4VvreEq0OUNBiZge7WwZODHHDEzi/Q4XTqPgknIQZHKCPjuqo3r2AXXDRwctBTazUgnv3ZEfkeMjLGW0LY17sX16Rzh4HVKJiCxmEkpPqvb+fjAgyqE29rO8w52ni1hRiGj0i9Ky3lt1lpMNQVgItiZWV95XUQT2icqm5jxwe1FOoFl1YxnyGSDD/uLnkFCVoPHN+sG+V9h0HiM1SF4VWAcuTbH8w/MVf8JCYINCFMqYhOSLKOFa+zQL+75sbygL6PEKS8tB1As9tTho4GBQNRCJV1RznBTVU7hoiTw="
+              ],
+              "cloud_instance_name": "microsoftonline.com",
+              "issuer": "https://login.microsoftonline.com/d884eee1-c96f-4701-8103-2ba4346db120/v2.0"
+            }
+          ]
+        }
+   """.trimIndent()
+
+    val response = mockk<HttpResponse<String>>() {
+        every { statusCode() } returns StatusCode.OK.code
+        every { body() } returns reponseBody
+    }
+
+    val client = mockk<HttpClient>() {
+        every { send(any(), HttpResponse.BodyHandlers.ofString()) } returns response
+    }
+
+    @Test
+    fun `fetches all the jwks`() {
+        val jwkProvider = ConfigurableJwkProvider(url, true, clientCreator)
+        val jwks = jwkProvider.allKeys
+
+        assertThat(jwks.count(), equalTo(2))
+    }
+
+
+}

--- a/src/test/kotlin/com/zepben/auth/server/ConfigurableJwkProviderTest.kt
+++ b/src/test/kotlin/com/zepben/auth/server/ConfigurableJwkProviderTest.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 package com.zepben.auth.server
 
 import com.zepben.auth.common.StatusCode

--- a/src/test/kotlin/com/zepben/auth/server/JWKHolderTest.kt
+++ b/src/test/kotlin/com/zepben/auth/server/JWKHolderTest.kt
@@ -10,7 +10,6 @@ package com.zepben.auth.server
 
 import com.auth0.jwk.Jwk
 import com.auth0.jwk.JwkException
-import com.auth0.jwk.UrlJwkProvider
 import com.zepben.auth.client.ProviderDetails
 import com.zepben.testutils.exception.ExpectException
 import io.mockk.every
@@ -161,13 +160,13 @@ class JWKHolderTest {
         )
 
         val returnedKeys = listOf(key1, key2, key3, key4, key5, key6)
-        val mockJwkProvider = mockk<UrlJwkProvider> {
-            every { all } returns returnedKeys
+        val mockJwkProvider = mockk<ConfigurableJwkProvider> {
+            every { allKeys } returns returnedKeys
         }
 
         val keysUrl = URI(keysUrlRaw).toURL()
 
-        val mockUrlJwkProviderProvider = mockk<(URL) -> UrlJwkProvider> {
+        val mockUrlJwkProviderProvider = mockk<(URL) -> ConfigurableJwkProvider> {
             every { this@mockk(keysUrl) } returns mockJwkProvider
         }
 
@@ -177,7 +176,7 @@ class JWKHolderTest {
             issuer.providerDetails
             providerDetails.jwkUrl
             mockUrlJwkProviderProvider.invoke(keysUrl)
-            mockJwkProvider.all
+            mockJwkProvider.allKeys
         }
     }
 }

--- a/src/test/kotlin/com/zepben/auth/server/JWKHolderTest.kt
+++ b/src/test/kotlin/com/zepben/auth/server/JWKHolderTest.kt
@@ -42,7 +42,7 @@ class JWKHolderTest {
         every { it(trustedIssuerTwo) } returns mapOf("common_key_id" to jwkCommonTwo)
     }
 
-    private val holderUnderTest = JWKHolder(jwkProvider)
+    private val holderUnderTest = JWKHolder(true, jwkProvider)
 
     @Test
     fun `JWKHolder refreshes keys from issuer if kid not found in cache`() {

--- a/src/test/kotlin/com/zepben/auth/server/JWTAuthenticatorTest.kt
+++ b/src/test/kotlin/com/zepben/auth/server/JWTAuthenticatorTest.kt
@@ -32,7 +32,8 @@ class JWTAuthenticatorTest {
             verifierBuilder = JWTMultiIssuerVerifierBuilder(
                 "https://fake-aud/",
                 listOf(TrustedIssuer("https://issuer/", ProviderDetails("dunno", "https://whereileft.my/keys/"))),
-                JWKHolder { _ -> MockJwksUrlProvider().all.associateBy { it.id } } ))
+                true,
+                JWKHolder(true) { _ -> MockJwksUrlProvider().all.associateBy { it.id } } ))
 
         var authResp = ta.authenticate(TOKEN)
         assertThat(authResp.statusCode, equalTo(StatusCode.OK))
@@ -64,7 +65,8 @@ class JWTAuthenticatorTest {
             verifierBuilder = JWTMultiIssuerVerifierBuilder(
                 "https://wrong-aud/",
                 listOf(TrustedIssuer("https://issuer/", ProviderDetails("dunno", "https://whereileft.my/keys/"))),
-                JWKHolder { _ -> MockJwksUrlProvider().all.associateBy { it.id } } ))
+                true,
+                JWKHolder(true) { _ -> MockJwksUrlProvider().all.associateBy { it.id } } ))
 
         authResp = ta.authenticate(TOKEN)
         assertThat(authResp.statusCode, equalTo(StatusCode.PERMISSION_DENIED))
@@ -75,7 +77,8 @@ class JWTAuthenticatorTest {
             verifierBuilder = JWTMultiIssuerVerifierBuilder(
                 "https://fake-aud/",
                 listOf(TrustedIssuer("wrong-issuer", ProviderDetails("dunno", "https://whereileft.my/keys/"))),
-                JWKHolder { _ -> MockJwksUrlProvider().all.associateBy { it.id } } ))
+                true,
+                JWKHolder(true) { _ -> MockJwksUrlProvider().all.associateBy { it.id } } ))
 
         authResp = ta.authenticate(TOKEN)
         assertThat(authResp.statusCode, equalTo(StatusCode.PERMISSION_DENIED))
@@ -90,8 +93,8 @@ class JWTAuthenticatorTest {
             every { all } returns listOf(jwk)
         }
 
-        val ta = JWTMultiIssuerVerifierBuilder("https://fake-aud/", listOf(TrustedIssuer("https://issuer/", ProviderDetails("dunno", "https://whereileftmy/keys/")))
-        , JWKHolder { _ -> mockJWK.all.associateBy { it.id } } )
+        val ta = JWTMultiIssuerVerifierBuilder("https://fake-aud/", listOf(TrustedIssuer("https://issuer/", ProviderDetails("dunno", "https://whereileftmy/keys/"))), true,
+            JWKHolder(true) { _ -> mockJWK.all.associateBy { it.id } } )
         assertThat(ta.jwkHolder.getKeyFromJwk("fakekid", TrustedIssuer("ignored_for_now", ProviderDetails("",""))), equalTo(jwk))
 
         expect {

--- a/src/test/kotlin/com/zepben/auth/server/JWTMultiIssuerVerifierBuilderTest.kt
+++ b/src/test/kotlin/com/zepben/auth/server/JWTMultiIssuerVerifierBuilderTest.kt
@@ -43,7 +43,8 @@ class JWTMultiIssuerVerifierBuilderTest {
         val underTest = JWTMultiIssuerVerifierBuilder(
             requiredAudience = "aud",
             trustedIssuers = trustedIssuers,
-            jwkHolder = jwkHolder
+            jwkHolder = jwkHolder,
+            verifyCertificates = true
         )
 
         val token = mockk<DecodedJWT> {
@@ -68,7 +69,8 @@ class JWTMultiIssuerVerifierBuilderTest {
         val underTest = JWTMultiIssuerVerifierBuilder(
             requiredAudience = "aud",
             trustedIssuers = trustedIssuers,
-            jwkHolder = jwkHolder
+            jwkHolder = jwkHolder,
+            verifyCertificates = true
         )
 
         val token = mockk<DecodedJWT> {
@@ -93,7 +95,8 @@ class JWTMultiIssuerVerifierBuilderTest {
         val underTest = JWTMultiIssuerVerifierBuilder(
             requiredAudience = "aud",
             trustedIssuers = emptyList(),
-            jwkHolder = jwkHolder
+            jwkHolder = jwkHolder,
+            verifyCertificates = true
         )
 
         val token = mockk<DecodedJWT> {
@@ -114,7 +117,8 @@ class JWTMultiIssuerVerifierBuilderTest {
         val underTest = JWTMultiIssuerVerifierBuilder(
             requiredAudience = "aud",
             trustedIssuers = trustedIssuers,
-            jwkHolder = jwkHolder
+            jwkHolder = jwkHolder,
+            verifyCertificates = true
         )
 
         val token = mockk<DecodedJWT> {

--- a/src/test/kotlin/com/zepben/auth/server/grpc/AuthInterceptorTest.kt
+++ b/src/test/kotlin/com/zepben/auth/server/grpc/AuthInterceptorTest.kt
@@ -31,9 +31,10 @@ class AuthInterceptorTest {
     fun testIntercept() {
         val ta = JWTAuthenticator("https://fake-aud/", listOf(TrustedIssuer("https://issuer/", ProviderDetails("dunno", "https://whereileftmy/keys/"))),
             verifierBuilder = JWTMultiIssuerVerifierBuilder(
-            "https://fake-aud/",
-            listOf(TrustedIssuer("https://issuer/", ProviderDetails("dunno", "https://whereileft.my/keys/"))),
-                JWKHolder { _ -> MockJwksUrlProvider().all.associateBy { it.id } } ))
+                "https://fake-aud/",
+                listOf(TrustedIssuer("https://issuer/", ProviderDetails("dunno", "https://whereileft.my/keys/"))),
+                verifyCertificates = true,
+                JWKHolder(true) { _ -> MockJwksUrlProvider().all.associateBy { it.id } } ))
         val requiredScopes = mapOf(
             "zepben.protobuf.np.NetworkProducer" to write_network_scope
         )
@@ -74,11 +75,14 @@ class AuthInterceptorTest {
 
     @Test
     fun `test provided authorise function is used`() {
-        val ta = JWTAuthenticator("https://fake-aud/", listOf(TrustedIssuer("https://issuer/", ProviderDetails("dunno", "https://whereileftmy/keys/"))),
-            verifierBuilder = JWTMultiIssuerVerifierBuilder(
+        val ta = JWTAuthenticator(
             "https://fake-aud/",
-            listOf(TrustedIssuer("https://issuer/", ProviderDetails("dunno", "https://whereileft.my/keys/"))),
-                JWKHolder { _ -> MockJwksUrlProvider().all.associateBy { it.id } } ))
+            listOf(TrustedIssuer("https://issuer/", ProviderDetails("dunno", "https://whereileftmy/keys/"))),
+            verifierBuilder = JWTMultiIssuerVerifierBuilder(
+                "https://fake-aud/",
+                listOf(TrustedIssuer("https://issuer/", ProviderDetails("dunno", "https://whereileft.my/keys/"))),
+                verifyCertificates = true,
+                JWKHolder(true) { _ -> MockJwksUrlProvider().all.associateBy { it.id } } ))
         var authoriseCalled = false
         val mdWithBearer = Metadata().apply { put(AUTHORIZATION_METADATA_KEY, "Bearer $TOKEN") }
         val sc = MockServerCall<Int, Int>({ _, _ -> })


### PR DESCRIPTION
# Description

When fetching JWKS keys, we need an option to disable certificate verification as in the Jemena environment they use internal DNS domains that only have self signed certificates attached to them. We have a similar problem locally when running applications with TLS enabled. 

This PR adds a new `verifyCertificates` option which allows the underlying HTTP client to be configured to just trust certificates. We tried to stick to an approach that is similar to the ZepbenTokenFetcher.

See inline code comments for some implementation details

# Associated tasks

- EAS PR - pending

# Test Steps

N/A

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- [ ] ~I have updated any documentation required for these changes.~

# Breaking Changes
- [ ] I have considered if this is a breaking change and will communicate it with other team members if so.
