### PR TITLE
[DEV-1821] Pass through verify certificates for the vertx auth route

### DIFF
--- a/src/main/kotlin/com/zepben/auth/server/AuthRoute.kt
+++ b/src/main/kotlin/com/zepben/auth/server/AuthRoute.kt
@@ -25,11 +25,12 @@ class AuthRoute {
          * Creates a route that has a handler implementing [io.vertx.ext.web.handler.AuthHandler] that supports
          * Auth0 JWTs using [JWTAuthProvider] and [JWTAuthenticator].
          *
-         * @param availableRoute The [AvailableRoute] for API version management.
          * @param path The path the [Route] should be built on
          * @param audience The audience required for JWT authentication
          * @param trustedIssuers The list of issuers trusted by the JWT authentication.
          * @param requiredClaims The claims required for the JWT for authorisation.
+         * @param isRegexPath If the path contains a regex
+         * @param verifyCertificates If the server certificates should be verified
          */
         @JvmOverloads
         @JvmStatic
@@ -39,6 +40,7 @@ class AuthRoute {
             trustedIssuers: List<TrustedIssuer>,
             requiredClaims: Iterable<String> = emptySet(),
             isRegexPath: Boolean = false,
+            verifyCertificates: Boolean = true
         ): (AvailableRoute) -> Route =
             { availableRoute ->
                 when (availableRoute) {
@@ -49,7 +51,7 @@ class AuthRoute {
                             .hasRegexPath(isRegexPath)
                             .addHandler(
                                 Auth0AuthHandler(
-                                    JWTAuthProvider(JWTAuthenticator(audience, trustedIssuers)),
+                                    JWTAuthProvider(JWTAuthenticator(audience, trustedIssuers, verifyCertificates)),
                                     mutableSetOf<String>().apply { addAll(requiredClaims) },
                                 )
                             )


### PR DESCRIPTION
# Description

Missed it as part of #22. This is required so that EWB can also disable verify certificates. Intentionally didn't update the changelog as it is part of the previous change.

# Associated tasks

None

# Test Steps

N/A

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [ ] I have updated the changelog. - intentionally didn't
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.
